### PR TITLE
Configure ORM for fantasy-f1-service #6

### DIFF
--- a/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/FantasyF1ServiceMain.java
+++ b/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/FantasyF1ServiceMain.java
@@ -1,0 +1,40 @@
+package com.aklysoft.fantasyf1.service;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.info.Contact;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.info.License;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import javax.ws.rs.core.Application;
+
+@QuarkusMain
+public class FantasyF1ServiceMain {
+
+  public static void main(String... args) {
+    System.out.println("Running main method");
+    Quarkus.run(args);
+  }
+
+  @OpenAPIDefinition(
+          tags = {
+                  @Tag(name = "player", description = "Player operations."),
+                  @Tag(name = "admin", description = "Admin Operations.")
+          },
+          info = @Info(
+                  title = "Fantasy-F1 API",
+                  version = "1.0.0",
+                  contact = @Contact(
+                          name = "Fantasy-F1 Support",
+                          url = "http://fantasyf1.com/contact",
+                          email = "szilard.antal@aklysoft.hu"),
+                  license = @License(
+                          name = "Apache 2.0",
+                          url = "http://www.apache.org/licenses/LICENSE-2.0.html"))
+  )
+  public static class FantasyF1RsApp extends Application {
+  }
+
+}

--- a/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/core/orm/GeneralRepository.java
+++ b/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/core/orm/GeneralRepository.java
@@ -1,0 +1,15 @@
+package com.aklysoft.fantasyf1.service.core.orm;
+
+import java.util.List;
+
+public interface GeneralRepository<T, ID> {
+  void persist(T entity);
+
+  void delete(T entity);
+
+  T findById(ID id);
+
+  List<T> findAll();
+
+  void deleteById(ID id);
+}

--- a/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/core/orm/GeneralRepositoryImpl.java
+++ b/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/core/orm/GeneralRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.aklysoft.fantasyf1.service.core.orm;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+public abstract class GeneralRepositoryImpl<T, ID> implements GeneralRepository<T, ID> {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  private Class<T> entityClazz;
+  private Class<ID> idClass;
+
+  public GeneralRepositoryImpl(Class<T> entityClazz, Class<ID> idClass) {
+    this.entityClazz = entityClazz;
+    this.idClass = idClass;
+  }
+
+  @Override
+  public void persist(T entity) {
+    entityManager.persist(entity);
+  }
+
+  @Override
+  public void delete(T entity) {
+    entityManager.remove(entity);
+  }
+
+  @Override
+  public T findById(ID id) {
+    return entityManager.find(entityClazz, id);
+  }
+
+  @Override
+  public List<T> findAll() {
+    return entityManager.createQuery("FROM " + entityClazz.getSimpleName(), entityClazz).getResultList();
+  }
+
+  @Override
+  public void deleteById(ID id) {
+    T entity = findById(id);
+    delete(entity);
+  }
+}

--- a/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/core/orm/SnakeCaseNamingStrategy.java
+++ b/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/core/orm/SnakeCaseNamingStrategy.java
@@ -1,0 +1,58 @@
+package com.aklysoft.fantasyf1.service.core.orm;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+import java.util.Locale;
+
+public final class SnakeCaseNamingStrategy implements PhysicalNamingStrategy {
+
+	@Override
+	public Identifier toPhysicalCatalogName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return name;
+	}
+
+	@Override
+	public Identifier toPhysicalSchemaName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return name;
+	}
+
+	@Override
+	public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		if (name == null) return null;
+		var tableName = name.getText();
+		if (!tableName.endsWith("s")) {
+			tableName = tableName.concat("s");
+		}
+		return Identifier.toIdentifier(tableName, name.isQuoted());
+	}
+
+	@Override
+	public Identifier toPhysicalSequenceName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return toSnakeCase(name);
+	}
+
+	@Override
+	public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return toSnakeCase(name);
+	}
+
+	private static Identifier toSnakeCase(Identifier name) {
+		if (name == null) return null;
+		String snakeCase = toSnakeCase(name.getText());
+		return Identifier.toIdentifier(snakeCase, name.isQuoted());
+	}
+
+
+	private static String toSnakeCase(String text) {
+		var buf = new StringBuilder(text);
+		for (int i = 1; i < buf.length() - 1; i++) {
+			if (Character.isLowerCase(buf.charAt(i - 1)) && Character.isUpperCase(buf.charAt(i))
+					&& Character.isLowerCase(buf.charAt(i + 1))) {
+				buf.insert(i++, '_');
+			}
+		}
+		return buf.toString().toLowerCase(Locale.ROOT);
+	}
+}

--- a/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/greetings/GreetingsResource.java
+++ b/fantasy-f1-service/src/main/java/com/aklysoft/fantasyf1/service/greetings/GreetingsResource.java
@@ -1,12 +1,15 @@
-package com.aklysoft.fantasyf1.service;
+package com.aklysoft.fantasyf1.service.greetings;
+
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-@Path("/hello")
-public class ExampleResource {
+@Path("/api/v1/hello")
+@Tag(name = "admin")
+public class GreetingsResource {
 
   @GET
   @Produces(MediaType.TEXT_PLAIN)

--- a/fantasy-f1-service/src/main/resources/application.properties
+++ b/fantasy-f1-service/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-# Configuration file
-# key = value

--- a/fantasy-f1-service/src/main/resources/application.yml
+++ b/fantasy-f1-service/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+quarkus:
+  http:
+    port: 8080
+  swagger-ui:
+    always-include: true
+    path: /api
+  datasource:
+    url: jdbc:postgresql://${POSTGRES_DB_HOST:localhost}/${QUARKUS_TODO_DB:fantasy_f1}
+    driver: org.postgresql.Driver
+    username: ${POSTGRES_USER:admin}
+    password: ${POSTGRES_PASSWORD:admin}
+    max-size: 8
+    min-size: 2
+  hibernate-orm:
+    physical-naming-strategy: com.aklysoft.fantasyf1.service.core.orm.SnakeCaseNamingStrategy
+    database:
+      generation: drop-and-create
+  container-image:
+#    group: aklysoft
+    name: fantasy-f1-service
+    tag: 1.0.0-SNAPSHOT
+  kubernetes:
+    service-type: load-balancer
+
+

--- a/fantasy-f1-service/src/test/java/com/aklysoft/NativeExampleResourceIT.java
+++ b/fantasy-f1-service/src/test/java/com/aklysoft/NativeExampleResourceIT.java
@@ -1,9 +1,0 @@
-package com.aklysoft;
-
-import io.quarkus.test.junit.NativeImageTest;
-
-@NativeImageTest
-public class NativeExampleResourceIT extends ExampleResourceTest {
-
-  // Execute the same tests but in native mode.
-}

--- a/fantasy-f1-service/src/test/java/com/aklysoft/fantasyf1/service/greetings/GreetingsResourceTest.java
+++ b/fantasy-f1-service/src/test/java/com/aklysoft/fantasyf1/service/greetings/GreetingsResourceTest.java
@@ -1,21 +1,22 @@
-package com.aklysoft;
+package com.aklysoft.fantasyf1.service.greetings;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-public class ExampleResourceTest {
+public class GreetingsResourceTest {
 
   @Test
   public void testHelloEndpoint() {
     given()
-            .when().get("/hello")
+            .when().get("/api/v1/hello")
             .then()
             .statusCode(200)
-            .body(is("hello"));
+            .body(containsString("hello"));
   }
 
 }

--- a/fantasy-f1-service/src/test/java/com/aklysoft/fantasyf1/service/greetings/NativeGreetingsResourceIT.java
+++ b/fantasy-f1-service/src/test/java/com/aklysoft/fantasyf1/service/greetings/NativeGreetingsResourceIT.java
@@ -1,0 +1,9 @@
+package com.aklysoft.fantasyf1.service.greetings;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeGreetingsResourceIT extends GreetingsResourceTest {
+
+  // Execute the same tests but in native mode.
+}


### PR DESCRIPTION
- Connected the fantasy-f1-service to the infra database and configured the physical naming strategy. (issue #6) 
- Refactored generated ExampleResource 
- Added Quarkus Main
- Added jax-rs Application for OpenApi definition


